### PR TITLE
fix(deps): patch js-yaml DoS and bump @sveltejs/kit

### DIFF
--- a/myapp/package-lock.json
+++ b/myapp/package-lock.json
@@ -1174,9 +1174,9 @@
 			}
 		},
 		"node_modules/@sveltejs/kit": {
-			"version": "2.61.0",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.61.0.tgz",
-			"integrity": "sha512-beYjgUux5ITbZeL0vn6gipZlsQiXF1/08C/3F+vlbDvthb/CTgYpZsYPdRIi9RxgTwRSkKIvnxyl+ViZlX4q5A==",
+			"version": "2.66.0",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.66.0.tgz",
+			"integrity": "sha512-7nN4Ur4+nofZ36DVo83JbRe02m61Vc+I441mML/DYa1pUTZ/x26+lbrdqPen8gjmsUc6flMtHEqAtn0UfmfvAw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2665,10 +2665,20 @@
 			}
 		},
 		"node_modules/js-yaml": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-			"integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+			"integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
 			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/puzrin"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/nodeca"
+				}
+			],
 			"license": "MIT",
 			"dependencies": {
 				"argparse": "^2.0.1"
@@ -4043,24 +4053,6 @@
 				"yaml": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/tailwindcss/node_modules/yaml": {
-			"version": "2.9.0",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-			"integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-			"dev": true,
-			"license": "ISC",
-			"optional": true,
-			"peer": true,
-			"bin": {
-				"yaml": "bin.mjs"
-			},
-			"engines": {
-				"node": ">= 14.6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/eemeli"
 			}
 		},
 		"node_modules/tar-fs": {


### PR DESCRIPTION
## Summary
Non-breaking security fixes via `npm audit fix` (no `--force`).

- **js-yaml** 4.1.1 → 4.2.0 — patches quadratic-complexity DoS in merge-key handling ([GHSA-h67p-54hq-rp68](https://github.com/advisories/GHSA-h67p-54hq-rp68))
- **@sveltejs/kit** 2.61.0 → 2.66.0

Only the lockfile changed. `npm run build` verified passing.

## Deferred (require major-version upgrades)
The 7 open Dependabot alerts on `main` need breaking changes and are intentionally **not** in this PR:
- **svelte 4 → 5** (6 alerts: SSR XSS via spread attributes, `<svelte:element>`, DOM clobbering, etc.) — needs a dedicated migration with code changes + testing
- **vite 5 → 8** (1 alert: dev-server only, no production impact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)